### PR TITLE
Upgrade traefik to v3.0. Added postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ With 5 simple steps you should be able to use hostnames instead of ports:
 3. Link your docker network to the `development-proxy` network
 4. Add your local url to your `/etc/hosts` file 
 5. (optional) Add SSL certificates for https
+    * Not optional if you want to use Postgres with Traefik
 
 Ready? [Set up the development proxy](./setup.md) for your project(s).
 

--- a/setup-postgres.md
+++ b/setup-postgres.md
@@ -1,0 +1,58 @@
+# Set up postgres with SSL (SSL Required for postgres)
+
+Requirements: [mkcert](https://github.com/FiloSottile/mkcert#installation) (don't forget to run `mkcert -install` after installation!)
+
+Before you start, you must have [the development proxy](./setup.md) running.
+
+## 1. Add labels in docker compose
+
+Add the `tls`, and `entrypoints` label to your router:
+
+```yaml
+services:
+  postgres:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.my-project-postgres.rule=HostSNI(`postgres.my-project.local`)"
+      - "traefik.tcp.routers.my-project-postgres.tls=true"
+      - "traefik.tcp.routers.my-project-postgres.entrypoints=pg-tcp"
+      - "traefik.tcp.services.my-project-postgres.loadbalancer.server.port=5432"
+```
+
+## 2. Create certificates and copy them to the dev proxy**
+
+To create certificates use `mkcert`.
+
+For example: `mkcert postgres.my-project.local`
+
+Copy the generated files to the dev proxy certificates folder: `cp ./postgres.my-project.local+1* ~/.development-proxy/certs/`
+
+## 3. Create a tls configuration for your project**
+
+Create a configuration file `my-project.yml`
+
+```yaml
+tls:
+  certificates:
+    - certFile: /var/certs/postgres.my-project.local+1.pem
+      keyFile: /var/certs/postgres.my-project.local+1-key.pem
+```
+
+Copy the configuration to the dev proxy configuration folder: `cp ./my-project.yml ~/.development-proxy/certs/my-project.yml`
+
+## Automation
+
+Automating step 2 and 3 can be done with the following code below:
+
+```shell
+echo "\n=== Creating certificates ===\n"
+(mkdir -p ./dev/traefik-config/certs || true \
+	&& cd ./dev/traefik-config/certs \
+	&& (mkcert frontend.my-project.local backend.my-project.local postgres.my-project.local \
+	&& echo "> certificates created") \
+	|| echo "> could not create certificates, did you install mkcert?")
+echo "\n=== Copy dev proxy config ===\n"
+cp ./dev/traefik-config/my-project.yml ~/.development-proxy/config/my-project.yml
+cp ./dev/traefik-config/certs/* ~/.development-proxy/certs/
+echo "> configuration copied"
+```

--- a/start.sh
+++ b/start.sh
@@ -21,12 +21,13 @@ docker network create development-proxy > /dev/null 2>&1 || true
     --publish 80:80 \
     --publish 443:443 \
     --publish 10081:10081 \
+    --publish 5432:5432 \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
     --volume ~/.development-proxy/config:/var/config:ro \
     --volume ~/.development-proxy/certs:/var/certs:ro \
     --name development-proxy \
     --network development-proxy \
-    traefik:v2.10 \
+    traefik:v3.0 \
     --api.insecure=true \
     --providers.docker=true \
     --providers.docker.exposedbydefault=false \
@@ -34,4 +35,5 @@ docker network create development-proxy > /dev/null 2>&1 || true
     --providers.file.watch=true \
     --entrypoints.web.address=:80 \
     --entrypoints.web-secure.address=:443 \
-    --entrypoints.traefik.address=:10081 > /dev/null && echo "Started.")
+    --entrypoints.traefik.address=:10081 \
+    --entrypoints.pg-tcp.address=:5432 > /dev/null && echo "Started.")


### PR DESCRIPTION
# What
This PR adds PostgreSQL support to traefik/our development proxy.

Also upgrades traefik to 3.0. This was needed, ~~but I've found no breaking changes in the setup~~ see comment below...

# How to test
Feel free to reach out to me (on Slack) if you have any questions.

I already have some project working with this development proxy setup to show.