### PR TITLE
Make the proxy settings configurable

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -10,28 +10,62 @@ if ($(docker ps | grep -q development-proxy)); then
     exit 0
 fi
 
-mkdir -p ~/.development-proxy/config || true
-mkdir -p ~/.development-proxy/certs || true
+get_config() {
+    if [ -f "$DEVELOPMENT_PROXY_CONFIG_FILE" ]; then
+        docker run --rm -i -v "$DEVELOPMENT_PROXY_CONFIG_HOME":/workdir mikefarah/yq "$1" proxy-config.yml
+    fi
+}
+
+development_proxy_name="development-proxy"
+DEVELOPMENT_PROXY_CONFIG_HOME="${DEVELOPMENT_PROXY_CONFIG_HOME:-$HOME/.development-proxy}"
+DEVELOPMENT_PROXY_CONFIG_FILE="${DEVELOPMENT_PROXY_CONFIG_FILE:-$DEVELOPMENT_PROXY_CONFIG_HOME/proxy-config.yml}"
+
+mkdir -p $DEVELOPMENT_PROXY_CONFIG_HOME/config || true
+mkdir -p $DEVELOPMENT_PROXY_CONFIG_HOME/certs || true
+
+TRAEFIK_VERSION=${TRAEFIK_VERSION:-$(get_config ".traefik_version")}
+TRAEFIK_VERSION=${TRAEFIK_VERSION:-"v2.10"}
+
+TRAEFIK_DASH_PORT=${TRAEFIK_DASH_PORT:-$(get_config ".dashboard_port")}
+TRAEFIK_DASH_PORT="${TRAEFIK_DASH_PORT:-"10081"}"
+
+IFS='' read -d '' -r default_entrypoints <<EOF
+  --entrypoints.web.address=:80
+  --entrypoints.web-secure.address=:443
+  --entrypoints.traefik.address=:$TRAEFIK_DASH_PORT
+EOF
+IFS='' read -d '' -r default_exposed_ports <<EOF
+  --publish 80:80
+  --publish 443:443
+  --publish $TRAEFIK_DASH_PORT:$TRAEFIK_DASH_PORT
+EOF
+TREAFIK_ENTRYPOINTS="${TREAFIK_ENTRYPOINTS:-$default_entrypoints}"
+TRAEFIK_DOCKER_EXPOSED_PORTS="${TRAEFIK_DOCKER_EXPOSED_PORTS:-$default_exposed_ports}"
+
+entrypoints=$(get_config ".entrypoints" | tr -d ' ')
+for entrypoint in ${entrypoints}
+do
+    name=$(echo "$entrypoint" | sed 's/:/ /g' | cut -f1 -d' ')
+    port=$(echo "$entrypoint" | sed 's/:/ /g' | cut -f2 -d' ')
+    TREAFIK_ENTRYPOINTS="$TREAFIK_ENTRYPOINTS --entrypoints.${name}.address=:${port}"
+    TRAEFIK_DOCKER_EXPOSED_PORTS="$TRAEFIK_DOCKER_EXPOSED_PORTS --publish ${port}:${port}"
+done
 
 echo "Starting development proxy..."
 docker network create development-proxy > /dev/null 2>&1 || true
 (docker run \
     --detach \
     --rm \
-    --publish 80:80 \
-    --publish 443:443 \
-    --publish 10081:10081 \
+    $TRAEFIK_DOCKER_EXPOSED_PORTS \
     --volume /var/run/docker.sock:/var/run/docker.sock:ro \
-    --volume ~/.development-proxy/config:/var/config:ro \
-    --volume ~/.development-proxy/certs:/var/certs:ro \
-    --name development-proxy \
-    --network development-proxy \
-    traefik:v2.10 \
+    --volume $DEVELOPMENT_PROXY_CONFIG_HOME/config:/var/config:ro \
+    --volume $DEVELOPMENT_PROXY_CONFIG_HOME/certs:/var/certs:ro \
+    --name $development_proxy_name \
+    --network $development_proxy_name \
+    traefik:$TRAEFIK_VERSION \
     --api.insecure=true \
     --providers.docker=true \
     --providers.docker.exposedbydefault=false \
     --providers.file.directory=/var/config \
     --providers.file.watch=true \
-    --entrypoints.web.address=:80 \
-    --entrypoints.web-secure.address=:443 \
-    --entrypoints.traefik.address=:10081 > /dev/null && echo "Started.")
+    $TREAFIK_ENTRYPOINTS > /dev/null  && echo "Started.")


### PR DESCRIPTION
This PR makes the development proxy configurable via ENV variables and/or a config file.

Examples

~/.bashrc
```
export TRAEFIK_VERSION=v3.1
export TRAEFIK_DASH_PORT=3000
export DEVELOPMENT_PROXY_CONFIG_HOME=$XDG_CONFIG_HOME/development-proxy
```

~/.development-proxy/proxy-config.yml
```
traefik_version: v3.1
dashboard_port: 3000
entrypoints:
  postgresql: 5432
  zendserver: 10081
```